### PR TITLE
Fix: Add "Create your first project" text to empty state

### DIFF
--- a/frontend/app/components/ProjectList.tsx
+++ b/frontend/app/components/ProjectList.tsx
@@ -213,7 +213,7 @@ export default function ProjectList({
             No projects yet
           </h3>
           <p className="text-gray-600 dark:text-gray-400 max-w-md">
-            Get started by creating your first project. Projects help you organize your work and track progress.
+            Create your first project to get started. Projects help you organize your work and track progress.
           </p>
         </div>
       </div>

--- a/frontend/app/components/__tests__/ProjectList.test.tsx
+++ b/frontend/app/components/__tests__/ProjectList.test.tsx
@@ -147,7 +147,7 @@ describe('ProjectList', () => {
 
       await waitFor(() => {
         expect(screen.getByText('No projects yet')).toBeInTheDocument();
-        expect(screen.getByText(/Get started by creating your first project/i)).toBeInTheDocument();
+        expect(screen.getByText(/Create your first project/i)).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes #51 - Updates the empty state component to display "Create your first project" text as expected by E2E tests.

## Changes Made

- **Updated `frontend/app/components/ProjectList.tsx`**
  - Modified empty state paragraph text from "Get started by creating your first project" to "Create your first project to get started"
  - Text now appears at the beginning of the sentence for better visibility and matches E2E test expectations

- **Updated `frontend/app/components/__tests__/ProjectList.test.tsx`**
  - Updated unit test to match new text format
  - Changed regex from `/Get started by creating your first project/i` to `/Create your first project/i`

## Test Results

### Unit Tests
✅ All 202 tests passing  
✅ Coverage: 98.32% (exceeds threshold)

### E2E Tests
✅ `project-management.spec.ts:46` - "should show empty state when no projects exist" - **NOW PASSING**

The test successfully verifies:
- "No projects yet" heading is visible
- "Create your first project" text is visible
- No project cards are displayed

## Related Issues

- Fixes #51
- Related to #49 (Un-skip and stabilize E2E tests)

## Checklist

- [x] Code follows project style guidelines
- [x] All unit tests pass with 98%+ coverage
- [x] Target E2E test now passes
- [x] No breaking changes
- [x] Changes are minimal and focused on the specific issue