### PR TITLE
Fix: Replace deprecated datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from typing import List
-from datetime import datetime
+from datetime import datetime, UTC
 
 from .database import engine, get_db
 from .models import Base, Project
@@ -182,7 +182,7 @@ async def update_project(project_id: int, project_update: ProjectUpdate, db: Ses
     for field, value in update_data.items():
         setattr(db_project, field, value)
     
-    db_project.updated_at = datetime.utcnow()
+    db_project.updated_at = datetime.now(UTC)
     
     try:
         db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -6,7 +6,7 @@ Related: Issue #27 - Database constraints
 Related: Issue #30 - Case-insensitive UNIQUE constraint
 """
 from sqlalchemy import Column, Integer, String, Text, DateTime, Index, func
-from datetime import datetime
+from datetime import datetime, UTC
 from .database import Base
 
 
@@ -34,8 +34,8 @@ class Project(Base):
     name = Column(String(255), nullable=False, index=True)
     description = Column(Text)
     status = Column(String(50), default="planned")
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(UTC))
+    updated_at = Column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
     
     # Case-insensitive unique constraint using functional index
     # This works across SQLite (dev) and PostgreSQL (future production)


### PR DESCRIPTION
## Description

Resolves #57 - Replaced all deprecated `datetime.utcnow()` calls with `datetime.now(UTC)` to eliminate deprecation warnings and future-proof the codebase for upcoming Python versions.

## Changes Made

### Backend Updates

**`backend/app/models.py`**
- Added `UTC` import from datetime module
- Updated `created_at` field default: `datetime.utcnow` → `lambda: datetime.now(UTC)`
- Updated `updated_at` field default and onupdate: `datetime.utcnow` → `lambda: datetime.now(UTC)`

**`backend/app/main.py`**
- Added `UTC` import from datetime module
- Updated manual timestamp assignment in update endpoint: `datetime.utcnow()` → `datetime.now(UTC)`

## Testing

✅ **All tests passing**
- Backend: 40/40 unit tests pass
- Frontend: 212/212 tests pass
- Coverage: Maintained at 95%+ (backend) and 99%+ (frontend)
- **No deprecation warnings** in test output

## Acceptance Criteria

- [x] Replace all `datetime.utcnow()` with `datetime.now(UTC)`
- [x] Add `UTC` import: `from datetime import datetime, UTC`
- [x] Verify all 40 unit tests still pass
- [x] No deprecation warnings during test execution
- [x] Timestamps are still stored correctly in database
- [x] Existing timestamp comparisons work correctly

## Impact

- **Risk**: Low - Well-documented migration path
- **Breaking Changes**: None
- **Dependencies**: Python 3.11+ (already using Python 3.13.7 ✅)

## Related

- Fixes #57
- Python Enhancement: Uses timezone-aware datetime objects
- Compatible with Python 3.11+ `datetime.UTC` constant