### PR TITLE
feat: Add Template CRUD API Endpoints (Issue #169)

### DIFF
--- a/backend/unit_tests/test_templates_api.py
+++ b/backend/unit_tests/test_templates_api.py
@@ -478,6 +478,26 @@ class TestUpdateTemplate:
         assert response.status_code == 409
         assert "already exists" in response.json()["detail"]
 
+    def test_update_template_type_only_creates_duplicate(
+        self, client, create_sample_template
+    ):
+        """Test that updating type alone can create a duplicate and is detected."""
+        # Template A: type="title", content="{{test}}"
+        template_a = create_sample_template(
+            type="title", name="Template A", content="{{test}}"
+        )
+        # Template B: type="description", content="{{test}}"
+        create_sample_template(
+            type="description", name="Template B", content="{{test}}"
+        )
+
+        # Try to update Template A's type to "description" - should fail (duplicate)
+        update_data = {"type": "description"}
+        response = client.put(f"/api/templates/{template_a['id']}", json=update_data)
+
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"]
+
     def test_update_template_to_same_content_succeeds(
         self, client, create_sample_template
     ):


### PR DESCRIPTION
## Summary

Implements complete CRUD API for Template resource as specified in issue #169.

## Changes

### Endpoints Implemented

1. **POST `/api/templates`** - Create new template
   - Returns 201 Created on success
   - Returns 409 Conflict for duplicate (type, content) combinations (case-insensitive)
   - Returns 422 Unprocessable Entity for validation errors

2. **GET `/api/templates`** - List all templates
   - Optional `type` query parameter for filtering by template type
   - Results ordered by `created_at` descending (newest first)
   - Returns empty array if no templates exist

3. **GET `/api/templates/{template_id}`** - Get single template by ID
   - Returns 200 OK with template data
   - Returns 404 Not Found if template doesn't exist

4. **PUT `/api/templates/{template_id}`** - Update existing template
   - Supports partial updates (only provided fields are updated)
   - Returns 200 OK on success
   - Returns 409 Conflict for duplicate conflicts (case-insensitive)
   - Returns 404 Not Found if template doesn't exist
   - Returns 422 Unprocessable Entity for validation errors

5. **DELETE `/api/templates/{template_id}`** - Delete template
   - Returns 204 No Content on successful deletion
   - Returns 404 Not Found if template doesn't exist

### Key Features

✅ **Case-insensitive duplicate detection** - Uses SQLAlchemy's `func.lower()` to ensure unique (type, content) combinations regardless of case

✅ **Placeholder validation** - All templates must contain at least one placeholder in the format `{{placeholder_name}}`

✅ **Proper HTTP status codes** - Follows REST best practices for status codes

✅ **Clear error messages** - Descriptive error messages for all failure cases

✅ **Consistent API patterns** - Follows the same patterns as existing Projects and Workspaces endpoints

### Testing

- ✅ **43 comprehensive unit tests** organized into 5 test classes
- ✅ **96% overall code coverage** (exceeds 95% project requirement)
- ✅ **100% coverage on new Template endpoints**
- ✅ All validation rules tested (duplicates, placeholders, edge cases)
- ✅ Manual testing with curl verified all functionality

#### Test Coverage by Class

- **TestCreateTemplate**: 17 tests covering creation, duplicates, validation
- **TestListTemplates**: 6 tests for listing, filtering, ordering
- **TestGetTemplate**: 3 tests for retrieval and error handling
- **TestUpdateTemplate**: 14 tests for partial updates, validation, duplicates
- **TestDeleteTemplate**: 4 tests for deletion and recreation scenarios

### Code Quality

✅ All pre-commit checks passed:
- Ruff linting (no issues)
- mypy type checking (no issues)
- pytest with 95% coverage threshold (achieved 96%)

✅ Type hints on all functions

✅ Comprehensive docstrings

✅ Follows project conventions and existing patterns

## Dependencies

- **Based on**: #167 (Template database model) ✅
- **Based on**: #168 (Template Pydantic schemas) ✅
- **Part of**: Epic #166 (Template System)

## Related Issues

Closes #169

## Testing Instructions

### Manual Testing

```bash
# Start the dev server
cd backend
make run-dev

# Create a template
curl -X POST http://localhost:8000/api/templates \
  -H "Content-Type: application/json" \
  -d '{"type": "title", "content": "{{topic}} Tutorial for {{level}} Developers"}'

# List all templates
curl http://localhost:8000/api/templates

# Filter by type
curl http://localhost:8000/api/templates?type=title

# Get specific template
curl http://localhost:8000/api/templates/1

# Update template
curl -X PUT http://localhost:8000/api/templates/1 \
  -H "Content-Type: application/json" \
  -d '{"content": "{{topic}} Guide for {{level}} Engineers"}'

# Delete template
curl -X DELETE http://localhost:8000/api/templates/1
```

### Automated Testing

```bash
# Run all tests with coverage
cd backend
pytest unit_tests/ --cov=app --cov-report=term

# Run only template API tests
pytest unit_tests/test_templates_api.py -v
```

## Checklist

- [x] All acceptance criteria from issue #169 met
- [x] Code follows project style guidelines
- [x] Type hints added to all functions
- [x] Unit tests written with 95%+ coverage
- [x] Manual testing completed successfully
- [x] All pre-commit hooks pass
- [x] Documentation complete (docstrings)
- [x] No breaking changes to existing endpoints